### PR TITLE
Docker builds: Try to `--pull` newer images on every build

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -851,7 +851,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (err er
 		return err
 	}
 
-	buildcmd := []string{"docker", "build", "-t", version}
+	buildcmd := []string{"docker", "build", "--pull", "-t", version}
 	for arg, val := range cfg.BuildArgs {
 		buildcmd = append(buildcmd, "--build-arg", fmt.Sprintf("%s=%s", arg, val))
 	}


### PR DESCRIPTION
Fixes situations where leeway tries to build Docker packages based on old images although newer ones have already been published.

`docker build --pull` does a `pull` on every image mentioned in the `Dockerfile`, which in turn checks and download newer versions if necessary.