### PR TITLE
Compute package hashes using the package's definition only,

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -20,6 +20,7 @@ packages:
   prep:
   - ["echo", "hello prep"]
   config:
+    dontTest: true
     buildArgs:
     - -ldflags
     - -X main.version=${version}

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/typefox/leeway/pkg/leeway"
 	"github.com/typefox/leeway/pkg/prettyprint"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // describeCmd represents the describe command
@@ -156,6 +156,7 @@ type packageDescription struct {
 	Dependencies []packageMetadataDescription `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 	Config       configDescription            `json:"config,omitempty" yaml:"config,omitempty"`
 	Env          []string                     `json:"env,omitempty" yaml:"env,omitempty"`
+	Definition   string                       `json:"definition,omitempty"`
 }
 
 func newPackageDesription(pkg *leeway.Package) packageDescription {
@@ -214,6 +215,7 @@ func newPackageDesription(pkg *leeway.Package) packageDescription {
 		Env:          pkg.Environment,
 		Manifest:     manifest,
 		Config:       cfg,
+		Definition:   string(pkg.Definition),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -87,3 +87,5 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/leeway/workspace_test.go
+++ b/pkg/leeway/workspace_test.go
@@ -1,8 +1,17 @@
 package leeway_test
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestFixLoadWorkspace(t *testing.T) {
+func TestFixtureLoadWorkspace(t *testing.T) {
+	runDUT()
+
 	tests := []*CommandFixtureTest{
 		{
 			Name:              "single workspace packages",
@@ -18,7 +27,7 @@ func TestFixLoadWorkspace(t *testing.T) {
 			Args:              []string{"collect", "-w", "fixtures/nested-ws/wsa", "components"},
 			NoNestedWorkspace: true,
 			ExitCode:          0,
-			StdoutSub:         "pkg1\n//",
+			StdoutSub:         "//\npkg1",
 		},
 		{
 			Name:              "ignore nested workspaces",
@@ -46,5 +55,187 @@ func TestFixLoadWorkspace(t *testing.T) {
 
 	for _, test := range tests {
 		test.Run()
+	}
+}
+
+func TestPackageDefinition(t *testing.T) {
+	runDUT()
+
+	type pkginfo struct {
+		Metadata struct {
+			Version string `json:"version"`
+		} `json:"metadata"`
+	}
+
+	tests := []struct {
+		Name    string
+		Layouts []map[string]string
+		Tester  []func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest
+	}{
+		{
+			Name: "def change changes version",
+			Layouts: []map[string]string{
+				{
+					"WORKSPACE.yaml":  "",
+					"pkg1/BUILD.yaml": "packages:\n- name: foo\n  type: generic\n  srcs:\n  - \"doesNotExist\"",
+				},
+				{
+					"pkg1/BUILD.yaml": "packages:\n- name: foo\n  type: generic\n  srcs:\n  - \"alsoDoesNotExist\"",
+				},
+			},
+			Tester: []func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest{
+				func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest {
+					return &CommandFixtureTest{
+						T:    t,
+						Args: []string{"describe", "-w", loc, "-o", "json", "pkg1:foo"},
+						Eval: func(t *testing.T, stdout, stderr string) {
+							var dest pkginfo
+							err := json.Unmarshal([]byte(stdout), &dest)
+							if err != nil {
+								fmt.Println(stdout)
+								t.Fatal(err)
+							}
+							state["v"] = dest.Metadata.Version
+						},
+					}
+				},
+				func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest {
+					return &CommandFixtureTest{
+						T:    t,
+						Args: []string{"describe", "-w", loc, "-o", "json", "pkg1:foo"},
+						Eval: func(t *testing.T, stdout, stderr string) {
+							var dest pkginfo
+							err := json.Unmarshal([]byte(stdout), &dest)
+							if err != nil {
+								fmt.Println(stdout)
+								t.Fatal(err)
+							}
+							if state["v"] == dest.Metadata.Version {
+								t.Errorf("definition change did not change version")
+							}
+						},
+					}
+				},
+			},
+		},
+		{
+			Name: "comp change doesnt change version",
+			Layouts: []map[string]string{
+				{
+					"WORKSPACE.yaml":  "",
+					"pkg1/BUILD.yaml": "packages:\n- name: foo\n  type: generic\n  srcs:\n  - \"doesNotExist\"",
+				},
+				{
+					"pkg1/BUILD.yaml": "const:\n  foobar: baz\npackages:\n- name: foo\n  type: generic\n  srcs:\n  - \"doesNotExist\"",
+				},
+			},
+			Tester: []func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest{
+				func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest {
+					return &CommandFixtureTest{
+						T:    t,
+						Args: []string{"describe", "-w", loc, "-o", "json", "pkg1:foo"},
+						Eval: func(t *testing.T, stdout, stderr string) {
+							var dest pkginfo
+							err := json.Unmarshal([]byte(stdout), &dest)
+							if err != nil {
+								fmt.Println(stdout)
+								t.Fatal(err)
+							}
+							state["v"] = dest.Metadata.Version
+						},
+					}
+				},
+				func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest {
+					return &CommandFixtureTest{
+						T:    t,
+						Args: []string{"describe", "-w", loc, "-o", "json", "pkg1:foo"},
+						Eval: func(t *testing.T, stdout, stderr string) {
+							var dest pkginfo
+							err := json.Unmarshal([]byte(stdout), &dest)
+							if err != nil {
+								fmt.Println(stdout)
+								t.Fatal(err)
+							}
+							if state["v"] != dest.Metadata.Version {
+								t.Errorf("component change did change package version")
+							}
+						},
+					}
+				},
+			},
+		},
+		{
+			Name: "dependency def change changes version",
+			Layouts: []map[string]string{
+				{
+					"WORKSPACE.yaml":  "",
+					"pkg1/BUILD.yaml": "packages:\n- name: foo\n  type: generic\n  srcs:\n  - \"doesNotExist\"\n- name: bar\n  type: generic\n  srcs:\n  - \"doesNotExist\"\n  deps:\n  - :foo",
+				},
+				{
+					"pkg1/BUILD.yaml": "packages:\n- name: foo\n  type: generic\n  srcs:\n  - \"alsoDoesNotExist\"\n- name: bar\n  type: generic\n  srcs:\n  - \"doesNotExist\"\n  deps:\n  - :foo",
+				},
+			},
+			Tester: []func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest{
+				func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest {
+					return &CommandFixtureTest{
+						T:    t,
+						Args: []string{"describe", "-w", loc, "-o", "json", "pkg1:foo"},
+						Eval: func(t *testing.T, stdout, stderr string) {
+							var dest pkginfo
+							err := json.Unmarshal([]byte(stdout), &dest)
+							if err != nil {
+								fmt.Println(stdout)
+								t.Fatal(err)
+							}
+							state["v"] = dest.Metadata.Version
+						},
+					}
+				},
+				func(t *testing.T, loc string, state map[string]string) *CommandFixtureTest {
+					return &CommandFixtureTest{
+						T:    t,
+						Args: []string{"describe", "-w", loc, "-o", "json", "pkg1:bar"},
+						Eval: func(t *testing.T, stdout, stderr string) {
+							var dest pkginfo
+							err := json.Unmarshal([]byte(stdout), &dest)
+							if err != nil {
+								fmt.Println(stdout)
+								t.Fatal(err)
+							}
+							if state["v"] == dest.Metadata.Version {
+								t.Errorf("dependency def change didn't change version")
+							}
+						},
+					}
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			loc, err := ioutil.TempDir("", "pkgdeftest-*")
+			if err != nil {
+				t.Fatalf("cannot create temporary dir: %q", err)
+			}
+
+			state := make(map[string]string)
+			for i, l := range test.Layouts {
+				for k, v := range l {
+					err := os.MkdirAll(filepath.Join(loc, filepath.Dir(k)), 0755)
+					if err != nil && !os.IsExist(err) {
+						t.Fatalf("cannot create filesystem layout: %q", err)
+					}
+					err = ioutil.WriteFile(filepath.Join(loc, k), []byte(v), 0644)
+					if err != nil && !os.IsExist(err) {
+						t.Fatalf("cannot create filesystem layout: %q", err)
+					}
+				}
+
+				tester := test.Tester[i](t, loc, state)
+				tester.Name = fmt.Sprintf("test-%003d", i)
+				tester.Run()
+			}
+		})
 	}
 }

--- a/pkg/prettyprint/prettyprint.go
+++ b/pkg/prettyprint/prettyprint.go
@@ -7,7 +7,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Format is an output format for pretty printing


### PR DESCRIPTION
instead of the entire component's `BUILD.yaml`.

Fixes TypeFox/leeway#9