### PR TITLE
[typescript] Disable yarn cache when installing offline-mirror package

### DIFF
--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -74,7 +74,7 @@ const (
 // buildProcessVersions contain the current version of the respective build processes.
 // Increment this value if you change any of the build procedures.
 var buildProcessVersions = map[PackageType]int{
-	TypescriptPackage: 5,
+	TypescriptPackage: 6,
 	GoPackage:         1,
 	DockerPackage:     1,
 	GenericPackage:    1,
@@ -544,8 +544,9 @@ export DIR=$(dirname "${BASH_SOURCE[0]}")
 cp $DIR/installer-package.json package.json
 $DIR/get_yarn_lock.sh > yarn.lock
 
-yarn install --frozenlockfile --prod
-rm yarn.lock
+mkdir -p _temp_yarn_cache
+yarn install --frozenlockfile --prod --cache-folder _temp_yarn_cache
+rm -r yarn.lock _temp_yarn_cache
 `
 
 	installerPackageJSONTemplate = `{"name":"local","version":"%s","license":"UNLICENSED","dependencies":{"%s":"%s"}}`


### PR DESCRIPTION
Thanks @meysholdt for your help in finding this bug in the first place.

Fixes TypeFox/leeway#18