### PR TITLE
[layout] Make build-time filesystem layout explicit

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -159,6 +159,7 @@ type packageDescription struct {
 	Manifest     map[string]string            `json:"manifest" yaml:"manifest"`
 	ArgDeps      []string                     `json:"argdeps,omitempty" yaml:"argdeps,omitempty"`
 	Dependencies []packageMetadataDescription `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Layout       map[string]string            `json:"layout,omitempty" yaml:"layout,omitempty"`
 	Config       configDescription            `json:"config,omitempty" yaml:"config,omitempty"`
 	Env          []string                     `json:"env,omitempty" yaml:"env,omitempty"`
 	Definition   string                       `json:"definition,omitempty"`
@@ -181,11 +182,17 @@ func newPackageDesription(pkg *leeway.Package) packageDescription {
 	}
 	sort.Slice(deps, func(i, j int) bool { return deps[i].FullName < deps[j].FullName })
 
+	layout := make(map[string]string)
+	for _, dep := range pkg.GetDependencies() {
+		layout[dep.FullName()] = pkg.BuildLayoutLocation(dep)
+	}
+
 	return packageDescription{
 		Metadata:     newMetadataDescription(pkg),
 		Type:         string(pkg.Type),
 		ArgDeps:      pkg.ArgumentDependencies,
 		Dependencies: deps,
+		Layout:       layout,
 		Env:          pkg.Environment,
 		Manifest:     manifest,
 		Config:       newConfigDescription(pkg.Type, pkg.Config),
@@ -249,6 +256,10 @@ Version Relevant Arguments:
 Dependencies:
 {{- range $k, $v := .Dependencies }}
 {{"\t"}}{{ $v.FullName -}}{{"\t"}}{{ $v.Version -}}
+{{ end }}
+Layout:
+{{- range $k, $v := .Layout }}
+{{"\t"}}{{ $k -}}{{"\t"}}{{ $v -}}
 {{ end -}}
 {{ end }}
 {{ if .Manifest -}}

--- a/pkg/leeway/build.go
+++ b/pkg/leeway/build.go
@@ -619,7 +619,7 @@ func (p *Package) buildYarn(buildctx *buildContext, wd, result string) (err erro
 			return PkgNotBuiltErr{deppkg}
 		}
 
-		tgt := deppkg.FilesystemSafeName()
+		tgt := p.BuildLayoutLocation(deppkg)
 		if cfg.Packaging == YarnOfflineMirror {
 			fn := fmt.Sprintf("%s.tar.gz", tgt)
 			commands = append(commands, []string{"cp", builtpkg, filepath.Join("_mirror", fn)})
@@ -803,7 +803,7 @@ func (p *Package) buildGo(buildctx *buildContext, wd, result string) (err error)
 				return PkgNotBuiltErr{dep}
 			}
 
-			tgt := filepath.Join("_deps", dep.FilesystemSafeName())
+			tgt := filepath.Join("_deps", p.BuildLayoutLocation(dep))
 			commands = append(commands, [][]string{
 				{"mkdir", tgt},
 				{"tar", "xfz", builtpkg, "-C", tgt},
@@ -869,7 +869,7 @@ func (p *Package) buildDocker(buildctx *buildContext, wd, result string) (err er
 			return PkgNotBuiltErr{dep}
 		}
 
-		tgt := dep.FilesystemSafeName()
+		tgt := p.BuildLayoutLocation(dep)
 		commands = append(commands, [][]string{
 			{"mkdir", tgt},
 			{"tar", "xfz", fn, "-C", tgt},
@@ -941,7 +941,7 @@ func (p *Package) buildGeneric(buildctx *buildContext, wd, result string) (err e
 			return PkgNotBuiltErr{dep}
 		}
 
-		tgt := dep.FilesystemSafeName()
+		tgt := p.BuildLayoutLocation(dep)
 		commands = append(commands, [][]string{
 			{"mkdir", tgt},
 			{"tar", "xfz", fn, "-C", tgt},

--- a/pkg/leeway/workspace.go
+++ b/pkg/leeway/workspace.go
@@ -489,6 +489,18 @@ func loadComponent(ctx context.Context, workspace *Workspace, path string, args 
 
 			pkg.Dependencies[idx] = comp.Name + dep
 		}
+		// make all layout entries full qualified
+		if pkg.Layout == nil {
+			pkg.Layout = make(map[string]string)
+		}
+		for dep, loc := range pkg.Layout {
+			if !strings.HasPrefix(dep, ":") {
+				continue
+			}
+
+			delete(pkg.Layout, dep)
+			pkg.Layout[comp.Name+dep] = loc
+		}
 
 		// apply variant config
 		if vnt := pkg.C.W.SelectedVariant; vnt != nil {

--- a/pkg/vet/docker.go
+++ b/pkg/vet/docker.go
@@ -72,7 +72,7 @@ func checkDockerCopyFromPackage(pkg *leeway.Package) ([]Finding, error) {
 			// we've found something that looks like a path - check if we have a dependency that could satisfy it
 			var satisfied bool
 			for _, dep := range pkg.GetDependencies() {
-				if dep.FilesystemSafeName() == pth {
+				if pkg.BuildLayoutLocation(dep) == pth {
 					satisfied = true
 					break
 				}

--- a/pkg/vet/generic.go
+++ b/pkg/vet/generic.go
@@ -32,7 +32,7 @@ func checkArgsReferingToPackage(pkg *leeway.Package) ([]Finding, error) {
 			// we've found something that looks like a path - check if we have a dependency that could satisfy it
 			var satisfied bool
 			for _, dep := range pkg.GetDependencies() {
-				if dep.FilesystemSafeName() == pth {
+				if pkg.BuildLayoutLocation(dep) == pth {
 					satisfied = true
 					break
 				}

--- a/pkg/vet/packages.go
+++ b/pkg/vet/packages.go
@@ -1,0 +1,30 @@
+package vet
+
+import (
+	"fmt"
+
+	"github.com/typefox/leeway/pkg/leeway"
+)
+
+func init() {
+	register(PackageCheck("build-layout", "validates the build layout of all packages", "", checkBuildLayout))
+}
+
+func checkBuildLayout(pkg *leeway.Package) (findings []Finding, err error) {
+	layoutIdx := make(map[string]string)
+	for dep, loc := range pkg.Layout {
+		otherdep, taken := layoutIdx[loc]
+		if !taken {
+			layoutIdx[loc] = dep
+			continue
+		}
+
+		findings = append(findings, Finding{
+			Description: fmt.Sprintf("build-time location %v is used by %v and %v", loc, dep, otherdep),
+			Component:   pkg.C,
+			Error:       true,
+			Package:     pkg,
+		})
+	}
+	return
+}


### PR DESCRIPTION
Prior to this change the build-time filesystem layout was created implicitly from the package names. This method breaks for nested workspaces where package names differ depending on their context.

This makes built-time layout explicit by introducing a "layout" section in the package description. If no explicit layout is set, leeway will fall back to its prior behaviour and use the dependency's filesystem safe name. This mechanism is implemented during linking s.t. the build-time layout stays stable across nested workspaces.

`leeway describe` has been updated accordingly to show the layout.
`leeway vet` finds layout path clashes if two dependencies occupy the same path at build-time.