### PR TITLE
[remote-caches] Support multiple remote caches (pull-only for now)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -165,6 +165,7 @@ func addBuildFlags(cmd *cobra.Command) {
 	}
 
 	cmd.Flags().StringP("cache", "c", cacheDefault, "Configures the caching behaviour: none=no caching, local=local caching only, remote-pull=download from remote but never upload, remote-push=push to remote cache only but don't download, remote=use all configured caches")
+	cmd.Flags().StringSlice("add-remote-cache", []string{}, "Configures additional (pull-only) remote caches")
 	cmd.Flags().Bool("dry-run", false, "Don't actually build but stop after showing what would need to be built")
 	cmd.Flags().String("dump-plan", "", "Writes the build plan as JSON to a file. Use \"-\" to write the build plan to stderr.")
 	cmd.Flags().Bool("werft", false, "Produce werft CI compatible output")
@@ -210,6 +211,16 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 		log.Fatal(err)
 	}
 
+	var arcs []leeway.RemoteCache
+	additionalRemoteCaches, _ := cmd.Flags().GetStringSlice("add-remote-cache")
+	for _, arc := range additionalRemoteCaches {
+		arcs = append(arcs, &pullOnlyRemoteCache{
+			C: leeway.GSUtilRemoteCache{
+				BucketName: arc,
+			},
+		})
+	}
+
 	dryrun, err := cmd.Flags().GetBool("dry-run")
 	if err != nil {
 		log.Fatal(err)
@@ -251,6 +262,7 @@ func getBuildOpts(cmd *cobra.Command) ([]leeway.BuildOption, *leeway.FilesystemC
 	return []leeway.BuildOption{
 		leeway.WithLocalCache(localCache),
 		leeway.WithRemoteCache(remoteCache),
+		leeway.WithAdditionalRemoteCaches(arcs),
 		leeway.WithDryRun(dryrun),
 		leeway.WithBuildPlan(planOutlet),
 		leeway.WithReporter(reporter),


### PR DESCRIPTION
This might serve as a first proposal for #31.

There are several things to discuss:
 - does it makes sense to merge `cache` and `(additional) remote cache`?
 - Does it make sense to have the `pull=` prefix to denote that it is a pull-only cache? I opted for that as it's the most compatible way in the future in both possible cases: 1. drop non-pull additional remote caches 2. add support for additional push-/pull+push-
 - Names names names: `remote-cache`, `additional-remote-cache`? (Depends on choice 1)